### PR TITLE
Generate attestation at a previous time

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -24,6 +24,10 @@ window.addEventListener("DOMContentLoaded", (event) => {
     document.getElementById("radio-animaux").checked = (reason==='animaux');
 
     var now = new Date()
+    if (urlParams.has("t")) {
+        const timedelta = urlParams.get("t"); //timedelta (in minutes)
+        now = new Date(now - timedelta * 60000)
+    }
     var timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "Europe/Paris"
 
     document.getElementById('field-datesortie').value = now.toJSON().slice(0,10);


### PR DESCRIPTION
I added a timedelta parameter (passed with the `t` field in `generate.js`). This field quantifies how far back (in minutes) you want to generate the attestation.
For example `generate.html#f=...&t=20` would generate a document dated 20 minutes ago.